### PR TITLE
Add option link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,29 +8,24 @@ Simple React component for rotating text.
 
 [build-badge]: https://img.shields.io/travis/claytonmarinho/react-text-rotator/master.png?style=flat-square
 [build]: https://travis-ci.org/claytonmarinho/react-text-rotator
-
 [npm-badge]: https://img.shields.io/npm/v/npm-package.png?style=flat-square
 [npm]: https://www.npmjs.org/package/npm-package
-
 [coveralls-badge]: https://img.shields.io/coveralls/claytonmarinho/react-text-rotator/master.png?style=flat-square
 [coveralls]: https://coveralls.io/github/claytonmarinho/react-text-rotator
 
 [See the demo](https://claytonmarinho.github.io/react-text-rotator/) | [Try on Codepen](https://codepen.io/claytonmarinho/pen/gOwLgNR)
 
-Getting Start
------------
+## Getting Start
 
 ```bash
 npm install react-text-rotator --save
 ```
 
-
-Usage
------------
+## Usage
 
 ```javascript
-import React from 'react';
-import ReactTextRotator from 'react-text-rotator';
+import React from "react";
+import ReactTextRotator from "react-text-rotator";
 
 const content = [
   {
@@ -42,6 +37,7 @@ const content = [
     text: "We shall fight on the landing grounds.",
     className: "classB",
     animation: "zoom",
+    link: "https://example.com/",
   },
   {
     text: "We shall fight in the fields and in the streets.",
@@ -57,43 +53,37 @@ const content = [
     text: "We shall never surrender...",
     className: "classE",
     animation: "zoom",
+    link: "https://example.org/",
   },
 ];
 
 const MyComponent = () => (
   <div>
     <h1>Churchill Speech</h1>
-    <ReactTextRotator
-      content={content}
-      time={5000}
-      startDelay={2000}
-    />
+    <ReactTextRotator content={content} time={5000} startDelay={2000} />
   </div>
 );
-
 ```
 
-Props
------------
+## Props
 
-| Name | Type | Required | Default | Obs |
-| --- | --- | --- | --- | --- |
-| content | Array | True | | Array of content shape (see bellow)
-| time | Number | False | 2500 | Time in milliseconds
-| startDelay | Number | False | 250 | Wait before the first content (milliseconds)
-| transitionTime | Number | False | 500 | Time in milliseconds
+| Name           | Type   | Required | Default | Obs                                          |
+| -------------- | ------ | -------- | ------- | -------------------------------------------- |
+| content        | Array  | True     |         | Array of content shape (see bellow)          |
+| time           | Number | False    | 2500    | Time in milliseconds                         |
+| startDelay     | Number | False    | 250     | Wait before the first content (milliseconds) |
+| transitionTime | Number | False    | 500     | Time in milliseconds                         |
 
 Content shape
 
-| Name | Type | Required | Default | Obs |
-| --- | --- | --- | --- | --- |
-| text | String | True | | Text to be shown
-| className | String | False | | Class name for each span
-| animation | String | False | 'fade' |  'fade', 'zoom' or 'squeeze' 
+| Name      | Type   | Required | Default | Obs                         |
+| --------- | ------ | -------- | ------- | --------------------------- |
+| text      | String | True     |         | Text to be shown            |
+| className | String | False    |         | Class name for each span    |
+| animation | String | False    | 'fade'  | 'fade', 'zoom' or 'squeeze' |
+| link      | String | False    |         | Optional hyperlink for text |
 
-
-Development
------------
+## Development
 
 ### Installation
 
@@ -118,4 +108,3 @@ Development
 - `npm run build` will build the component for publishing to npm and also bundle the demo app.
 
 - `npm run clean` will delete built resources.
-

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const content = [
     text: "We shall never surrender...",
     className: "classE",
     animation: "zoom",
-    link: "https://example.org/",
+    link: "https://google.com/",
   },
 ];
 

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -31,7 +31,7 @@ const content = [
     text: "We shall never surrender...",
     className: "classE",
     animation: "zoom",
-    link: "https://example.org/",
+    link: "https://google.com/",
   },
 ];
 

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -15,6 +15,7 @@ const content = [
     text: "We shall fight on the landing grounds.",
     className: "classB",
     animation: "zoom",
+    link: "https://example.com/",
   },
   {
     text: "We shall fight in the fields and in the streets.",
@@ -30,6 +31,7 @@ const content = [
     text: "We shall never surrender...",
     className: "classE",
     animation: "zoom",
+    link: "https://example.org/",
   },
 ];
 

--- a/demo/src/style.css
+++ b/demo/src/style.css
@@ -41,7 +41,6 @@ body {
 
 .classB {
   color: black;
-  text-decoration: underline;
 }
 
 .classC {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const TextRotator = ({ content, time, startDelay, transitionTime }) => {
     time,
   });
 
-  const { className = "", animation = "fade", text } = currentItemContent || {};
+  const { className = "", animation = "fade", text, link } = currentItemContent || {};
 
   return (
     <Transition in={isEntered} timeout={transitionTime}>
@@ -28,11 +28,19 @@ const TextRotator = ({ content, time, startDelay, transitionTime }) => {
           ...styles[`${animation}-${state}`],
         };
 
-        return (
-          <div key={indexRef} className={className} style={style}>
-            {text}
-          </div>
-        );
+        if (link) {
+          return (
+            <div key={indexRef} className={className} style={style}>
+              <a href={link}>{text}</a>
+            </div>
+          )
+        } else {
+          return (
+            <div key={indexRef} className={className} style={style}>
+              {text}
+            </div>
+          )
+        }
       }}
     </Transition>
   );
@@ -42,6 +50,7 @@ const ContentItem = PropTypes.shape({
   text: PropTypes.string.isRequired,
   className: PropTypes.string,
   animation: PropTypes.string,
+  link: PropTypes.string,
 });
 
 TextRotator.propTypes = {

--- a/src/index.js
+++ b/src/index.js
@@ -28,19 +28,12 @@ const TextRotator = ({ content, time, startDelay, transitionTime }) => {
           ...styles[`${animation}-${state}`],
         };
 
-        if (link) {
-          return (
-            <div key={indexRef} className={className} style={style}>
-              <a href={link}>{text}</a>
-            </div>
-          )
-        } else {
-          return (
-            <div key={indexRef} className={className} style={style}>
-              {text}
-            </div>
-          )
-        }
+        return (
+          <div key={indexRef} className={className} style={style}>
+            {link ? <a href={link}>{text}</a> : text}
+          </div>
+        )
+
       }}
     </Transition>
   );

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -71,4 +71,24 @@ describe("basic tests", () => {
 
     expect(component).toContain("");
   });
+
+  it("accepts hyperlinks as optional content item property", () => {
+    const props = {
+      content: [
+        {
+          text: "text a",
+          link: "https://example.com"
+        },
+      ],
+      time: 5000,
+      startDelay: 0,
+    };
+
+    const component = render(<ReactTextRotator {...props} />);
+
+    expect(component).toContain(
+      '<div class="" style="transition:opacity 500ms ease-in;opacity:0"><a href="https://example.com">text a</a></div>'
+    );
+  });
+
 });


### PR DESCRIPTION
Hi,

as requested, here's a pull request for adding optional link support to the text-rotator.

The changes are:
a) code in index.js to decide whether to render a link and addition of link propType
b) updates to README.txt for optional link
c) update to basic.js to add unit test for new behaviour
d) update to demo index.js for new optional links
e) update to demo style.css to remove underline style from classB (to make hyperlink underlining obvious)

Apologies - IDE auto formatting added a couple of format changes as well.

Fixes claytonmarinho/react-text-rotator#24

As I'm more of a backend dev (Java / Scala) and "get by" in React / Angular etc, I'll understand if you don't like the pull request :-)